### PR TITLE
added travis ci integration

### DIFF
--- a/.gemfile
+++ b/.gemfile
@@ -1,0 +1,7 @@
+source :rubygems
+
+puppetversion = ENV['PUPPET_VERSION']
+gem 'puppet', puppetversion, :require => false
+gem 'puppet-lint'
+gem 'rspec-puppet'
+gem 'puppetlabs_spec_helper', '>= 0.1.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+script:
+  - "rake lint"
+  - "rake spec SPEC_OPTS='--format documentation'"
+env:
+  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.0.0"
+  - PUPPET_VERSION="~> 3.1.0"
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+gemfile: .gemfile
+notifications:
+  email: false


### PR DESCRIPTION
Add config files for travis-ci (https://travis-ci.org/).  

This will automatically run spec tests on PRs as well as after things are merged.  To enable, login at travis-ci.org (uses oauth with github), go to your accounts, flip the off to on for this repo.

If you don't want this, just reject this PR.
