### PR TITLE
updated erb template

### DIFF
--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -1,11 +1,11 @@
 # Managed by Puppet! Do not edit locally.
-<% if comment then -%>
+<% if @comment then -%>
 #
-# <%= comment %>
+# <%= @comment %>
 <% end -%>
 
-User_Alias  <%= name.upcase %>_USERS = <%= users.class == Array ? users.join(", ") : users %>
-Runas_Alias <%= name.upcase %>_RUNAS = <%= runas.class == Array ? runas.join(", ") : runas %>
-Cmnd_Alias  <%= name.upcase %>_CMNDS = <%= cmnds.class == Array ? cmnds.join(", ") : cmnds %>
+User_Alias  <%= @name.upcase %>_USERS = <%= @users.class == Array ? @users.join(", ") : @users %>
+Runas_Alias <%= @name.upcase %>_RUNAS = <%= @runas.class == Array ? @runas.join(", ") : @runas %>
+Cmnd_Alias  <%= @name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.join(", ") : @cmnds %>
 
-<%= name.upcase %>_USERS ALL = (<%= name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= name.upcase %>_CMNDS
+<%= @name.upcase %>_USERS ALL = (<%= @name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @name.upcase %>_CMNDS


### PR DESCRIPTION
Hi -- Newer versions of Ruby/Puppet/ERB throw warnings about accessing variables in templates when they're not preceded by '@' ... I've added that to the sudoers template.  I haven't, unfortunately, been able to test: I'm not sure exactly how to get the test harness running, presumably you're more conversant with that than I.  

Thanks for the module, it's working great!
