### PR TITLE
Add support for setting Defaults

### DIFF
--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -47,11 +47,12 @@
 #
 define sudo::sudoers (
   $users,
-  $cmnds   = 'ALL',
-  $comment = undef,
-  $ensure  = 'present',
-  $runas   = ['root'],
-  $tags    = [],
+  $cmnds    = 'ALL',
+  $comment  = undef,
+  $ensure   = 'present',
+  $runas    = ['root'],
+  $tags     = [],
+  $defaults = [],
 ) {
   if $name !~ /^[A-Za-z0-9_]+$/ {
     fail 'Name should consist of letters numbers or underscores.'

--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -7,5 +7,9 @@
 User_Alias  <%= @name.upcase %>_USERS = <%= @users.class == Array ? @users.join(", ") : @users %>
 Runas_Alias <%= @name.upcase %>_RUNAS = <%= @runas.class == Array ? @runas.join(", ") : @runas %>
 Cmnd_Alias  <%= @name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.join(", ") : @cmnds %>
+<% if @defaults then -%>
+
+Defaults:<%= @name.upcase %>_USERS <%= @defaults.class == Array ? @defaults.join(", ") : @defaults %>
+<% end -%>
 
 <%= @name.upcase %>_USERS ALL = (<%= @name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @name.upcase %>_CMNDS


### PR DESCRIPTION
This is a simple change to support setting different Defaults for the users we manage sudoers rules for. I've used it like this on RHEL6 : 

``` puppet
sudo::sudoers { 'wheel':
  comment  => 'Full root privileges for wheel group members (with password)',
  users    => [ '%wheel' ],
  runas    => [ 'root' ],
  defaults => [ 'env_keep += "SSH_AUTH_SOCK"' ],
}
```

That way, even after `sudo su`, the members of the `wheel` group can use git+ssh.
