### PR TITLE
Fix sudoers.erb to stop writing an invalid "Defaults:" line if no defaults given

### DIFF
--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -7,7 +7,7 @@
 User_Alias  <%= @name.upcase %>_USERS = <%= @users.class == Array ? @users.join(", ") : @users %>
 Runas_Alias <%= @name.upcase %>_RUNAS = <%= @runas.class == Array ? @runas.join(", ") : @runas %>
 Cmnd_Alias  <%= @name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.join(", ") : @cmnds %>
-<% if @defaults then -%>
+<% if not @defaults.empty? then -%>
 
 Defaults:<%= @name.upcase %>_USERS <%= @defaults.class == Array ? @defaults.join(", ") : @defaults %>
 <% end -%>


### PR DESCRIPTION
Commit b17f148def17b6f12a74bb59d0b6b6fa0e721142 introduced a bug where leaving `defaults` as the default (an empty array) causes an invalid line to be written to the sudoers file. This happens because an empty array is considered to be `true` in Ruby, so the `if` check in the template will always be satisfied unless you explicitly pass `defaults => undef`. At least, that's how it works for me in Puppet v3.3.1. 

Sudo really doesn't like syntax errors, and once it hits the invalid line it will stop working with an error like the following:

```
sudo: >>> /etc/sudoers.d/admins: syntax error near line 7 <<< 
sudo: parse error in /etc/sudoers.d/admins near line 7
sudo: no valid sudoers sources found, quitting
sudo: unable to initialize policy plugin
```

If you don't have root access to the server, you'll be locked out of administering it at this point.
