### PR TITLE
Fix for puppet 3.4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@
 # Copyright 2013 Nxs Internet B.V.
 #
 class sudo (
-  $sudoers         = [],
+  $sudoers         = {},
   $manage_sudoersd = false,
   $sudoers_file    = ''
 ) {


### PR DESCRIPTION
With 3.4 the error "create_resources(): second argument must be a hash"
appeared, because the default empty array was no longer being ignored.
