### PR TITLE
Implement group support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ absent.
 
 Array of users that are allowed to execute the command(s).
 
+### group
+
+Group that is allowed to execute the command(s). Cannot be combined with 'users'.
+
 ### hosts
 
 Array of hosts that the command(s) can be executed on. Denying hosts using a bang/exclamation point may also be used.

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -15,6 +15,9 @@
 # [*users*]
 #   Array of users that are allowed to execute the command(s).
 #
+# [*group*]
+#   Group that can run the listed commands. Cannot be combined with users.
+#
 # [*hosts*]
 # Array of hosts that the command(s) can be executed on. Denying hosts using a bang/exclamation point may also be used.
 #
@@ -56,7 +59,8 @@
 # Copyright 2013 Nxs Internet B.V.
 #
 define sudo::sudoers (
-  $users,
+  $users    = undef,
+  $group    = undef,
   $hosts    = 'ALL',
   $cmnds    = 'ALL',
   $comment  = undef,
@@ -74,6 +78,10 @@ define sudo::sudoers (
 
   if $sane_name !~ /^[A-Za-z0-9_]+$/ {
     fail "Will not create sudoers file \"${sudoers_user_file}\" (for user \"${name}\") should consist of letters numbers or underscores."
+  }
+
+  if $users != undef and $group != undef {
+    fail 'You cannot define both a list of users and a group. Choose one.'
   }
 
   if $ensure == 'present' {

--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -4,7 +4,9 @@
 # <%= @comment %>
 <% end -%>
 
+<% if @users then -%>
 User_Alias  <%= @sane_name.upcase %>_USERS = <%= @users.class == Array ? @users.join(", ") : @users %>
+<% end -%>
 Host_Alias  <%= @sane_name.upcase %>_HOSTS = <%= @hosts.class == Array ? @hosts.join(", ") : @hosts %>
 Runas_Alias <%= @sane_name.upcase %>_RUNAS = <%= @runas.class == Array ? @runas.join(", ") : @runas %>
 Cmnd_Alias  <%= @sane_name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.join(", ") : @cmnds %>
@@ -14,4 +16,8 @@ Cmnd_Alias  <%= @sane_name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.
 Defaults:<%= @sane_name.upcase %>_USERS <%= @defaults.class == Array ? @defaults.join(", ") : @defaults %>
 <% end -%>
 
+<% if not @group == 'undef' then -%>
+%<%= @group %> <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
+<% else -%>
 <%= @sane_name.upcase %>_USERS <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
+<% end -%>

--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -16,8 +16,8 @@ Cmnd_Alias  <%= @sane_name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.
 Defaults:<%= @sane_name.upcase %>_USERS <%= @defaults.class == Array ? @defaults.join(", ") : @defaults %>
 <% end -%>
 
-<% if not @group == 'undef' then -%>
-%<%= @group %> <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
-<% else -%>
+<% if @users then -%>
 <%= @sane_name.upcase %>_USERS <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
+<% else -%>
+%<%= @group %> <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
 <% end -%>


### PR DESCRIPTION
These commits add support to use sudo's functionality to specify a group instead of a list of users. The canonical example of all sysadmins being in the wheel group and giving wheel access to run commands instead of listing out each admin's username is appropriate.