### PR TITLE
Added support for sudoers.d files with dashes in them.  Dashes will be

### DIFF
--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -1,7 +1,7 @@
 # == Define: sudo
 #
 # Allow restricted root access for specified users. The name of the defined
-# type must consist of only letters, numbers and underscores. If the name
+# type must consist of only letters, numbers, dashes and underscores. If the name
 # has incorrect characters the defined type will fail.
 #
 # === Parameters
@@ -14,6 +14,9 @@
 #
 # [*users*]
 #   Array of users that are allowed to execute the command(s).
+#
+# [*group*]
+#   Group that can run the listed commands. Cannot be combined with users.
 #
 # [*hosts*]
 # Array of hosts that the command(s) can be executed on. Denying hosts using a bang/exclamation point may also be used.
@@ -56,7 +59,8 @@
 # Copyright 2013 Nxs Internet B.V.
 #
 define sudo::sudoers (
-  $users,
+  $users    = undef,
+  $group    = undef,
   $hosts    = 'ALL',
   $cmnds    = 'ALL',
   $comment  = undef,
@@ -72,8 +76,12 @@ define sudo::sudoers (
   $sane_name = regsubst($name, '\.', '_', 'G')
   $sudoers_user_file = "/etc/sudoers.d/${sane_name}"
 
-  if $sane_name !~ /^[A-Za-z0-9_]+$/ {
-    fail "Will not create sudoers file \"${sudoers_user_file}\" (for user \"${name}\") should consist of letters numbers or underscores."
+  if $sane_name !~ /^[A-Za-z0-9_\-]+$/ {
+    fail "Will not create sudoers file \"${sudoers_user_file}\" (for user \"${name}\") should consist of letters, numbers, dashes or underscores."
+  }
+
+  if $users != undef and $group != undef {
+    fail 'You cannot define both a list of users and a group. Choose one.'
   }
 
   if $ensure == 'present' {

--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -24,6 +24,8 @@ Defaults:<%= @sane_name.upcase.gsub("-", "_") %>_USERS <%= @defaults.class == Ar
 <% if @users then -%>
 <%= @sane_name.upcase.gsub("-", "_") %>_USERS <%= @sane_name.upcase.gsub("-", "_") %>_HOSTS = (<%= @sane_name.upcase.gsub("-", "_") %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase.gsub("-", "_") %>_CMNDS
 <% else -%>
-%<%= @group %> <%= @sane_name.upcase.gsub("-", "_") %>_HOSTS = (<%= @sane_name.upcase.gsub("-", "_") %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase.gsub("-", "_") %>_CMNDS
+<% @group.each do |this_group| -%>
+%<%= this_group %> <%= @sane_name.upcase.gsub("-", "_") %>_HOSTS = (<%= @sane_name.upcase.gsub("-", "_") %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase.gsub("-", "_") %>_CMNDS
+<% end -%>
 <% end -%>
 

--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -4,14 +4,26 @@
 # <%= @comment %>
 <% end -%>
 
-User_Alias  <%= @sane_name.upcase %>_USERS = <%= @users.class == Array ? @users.join(", ") : @users %>
-Host_Alias  <%= @sane_name.upcase %>_HOSTS = <%= @hosts.class == Array ? @hosts.join(", ") : @hosts %>
-Runas_Alias <%= @sane_name.upcase %>_RUNAS = <%= @runas.class == Array ? @runas.join(", ") : @runas %>
-Cmnd_Alias  <%= @sane_name.upcase %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.join(", ") : @cmnds %>
+<%# The use of the gsub("-", "_") is to convert dashes in the Alias names to underscores -%>
+<%# This allows the use of dashes in the sudoers.d file name while maintaining compatibility -%>
+<%# with the sudoers format (which does not allow dashes in Alias names but does allow underscores -%>
+# Any conversion of dashes to underscores is to maintain compatibility with
+# the sudoers Alias definitions.  See `man sudoers` for more information.
+<% if @users then -%>
+User_Alias  <%= @sane_name.upcase.gsub("-", "_") %>_USERS = <%= @users.class == Array ? @users.join(", ") : @users %>
+<% end -%>
+Host_Alias  <%= @sane_name.upcase.gsub("-", "_") %>_HOSTS = <%= @hosts.class == Array ? @hosts.join(", ") : @hosts %>
+Runas_Alias <%= @sane_name.upcase.gsub("-", "_") %>_RUNAS = <%= @runas.class == Array ? @runas.join(", ") : @runas %>
+Cmnd_Alias  <%= @sane_name.upcase.gsub("-", "_") %>_CMNDS = <%= @cmnds.class == Array ? @cmnds.join(", ") : @cmnds %>
 
 <% if not @defaults.empty? then -%>
 
-Defaults:<%= @sane_name.upcase %>_USERS <%= @defaults.class == Array ? @defaults.join(", ") : @defaults %>
+Defaults:<%= @sane_name.upcase.gsub("-", "_") %>_USERS <%= @defaults.class == Array ? @defaults.join(", ") : @defaults %>
 <% end -%>
 
-<%= @sane_name.upcase %>_USERS <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
+<% if @users then -%>
+<%= @sane_name.upcase.gsub("-", "_") %>_USERS <%= @sane_name.upcase.gsub("-", "_") %>_HOSTS = (<%= @sane_name.upcase.gsub("-", "_") %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase.gsub("-", "_") %>_CMNDS
+<% else -%>
+%<%= @group %> <%= @sane_name.upcase.gsub("-", "_") %>_HOSTS = (<%= @sane_name.upcase.gsub("-", "_") %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase.gsub("-", "_") %>_CMNDS
+<% end -%>
+


### PR DESCRIPTION
converted to underscores in the sudoers.d file to maintain compatibility
with the 'Alias' functions.  (see `man sudoers`) It is OK to have a dash
in the sudoers.d file name so dashes are -not- removed from the file
name itself.
