### PR TITLE
Support tags passed as strings with Ruby 2.x

### DIFF
--- a/spec/defines/sudo_sudoers_spec.rb
+++ b/spec/defines/sudo_sudoers_spec.rb
@@ -45,6 +45,24 @@ describe 'sudo::sudoers', :type => :define do
     it { should contain_file('/etc/sudoers.d/world_domination').with_content(/Defaults!WORLD_DOMINATION_CMNDS env_keep \+= "SSH_AUTH_SOCK"/) }
 
   end
+
+  context 'using strings instead of arrays' do
+    let(:params) { {
+      :users    => 'riton',
+      :runas    => 'root',
+      :cmnds    => '/bin/bash',
+      :tags     => 'NOPASSWD',
+      :defaults => 'env_keep += "KRB5CCNAME"'
+    } }
+
+    it { should contain_file('/etc/sudoers.d/world_domination').with_content(/^User_Alias\s*WORLD_DOMINATION_USERS\s=\sriton$/) }
+    it { should contain_file('/etc/sudoers.d/world_domination').with_content(/^Runas_Alias\s*WORLD_DOMINATION_RUNAS\s=\sroot$/) }
+    it { should contain_file('/etc/sudoers.d/world_domination').with_content(/^Cmnd_Alias\s*WORLD_DOMINATION_CMNDS\s=\s\/bin\/bash$/) }
+    it { should contain_file('/etc/sudoers.d/world_domination').with_content(/^WORLD_DOMINATION_USERS\sWORLD_DOMINATION_HOSTS\s=\s\(WORLD_DOMINATION_RUNAS\)\sNOPASSWD:\sWORLD_DOMINATION_CMNDS$/) }
+
+    it { should contain_file('/etc/sudoers.d/world_domination').with_content(/Defaults!WORLD_DOMINATION_CMNDS env_keep \+= "KRB5CCNAME"/) }
+  end
+
   if (Puppet.version >= '3.5.0')
     context "validating content with puppet #{Puppet.version}" do
       let(:params) { { :users => ['joe'] } }

--- a/templates/sudoers.erb
+++ b/templates/sudoers.erb
@@ -1,4 +1,9 @@
 # Managed by Puppet! Do not edit locally.
+
+<%-
+  tags = @tags.class == Array ? @tags.map{|x| x.sub(/$/, ':')}.join(' ') : "#{@tags}:"
+-%>
+
 <% if @comment then -%>
 #
 # <%= @comment %>
@@ -16,7 +21,7 @@ Defaults!<%= @sane_name.upcase %>_CMNDS <%= @defaults.class == Array ? @defaults
 <% end -%>
 
 <% if @users then -%>
-<%= @sane_name.upcase %>_USERS <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
+<%= @sane_name.upcase %>_USERS <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= tags %> <%= @sane_name.upcase %>_CMNDS
 <% else -%>
-%<%= @group %> <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= @tags.map{|x| x.sub(/$/, ':')}.join(' ') %> <%= @sane_name.upcase %>_CMNDS
+%<%= @group %> <%= @sane_name.upcase %>_HOSTS = (<%= @sane_name.upcase %>_RUNAS) <%= tags %> <%= @sane_name.upcase %>_CMNDS
 <% end -%>


### PR DESCRIPTION
- In RedHat 6.x and Ruby 1.8.x, tags passed as strings were supported and functionnal.
- In RedHat 7.x and ruby 2.x, tags passed as strings raise an error `NoMethodError: undefined method`map'`

This commit handle both cases as it was done for other options and should not introduce backward compatibility.
