### PR TITLE
Add prefix parameter to the sudoers definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ NOSETENV, LOG_INPUT, NOLOG_INPUT, LOG_OUTPUT and NOLOG_OUTPUT.
 
 Override some of the compiled in default values for sudo.
 
+### prefix
+
+Prefix for the file created for the rule, when ordering matters as the last
+one matching is the one taken into account. Typically '00', '50', '99', etc.
+The default is no prefix, with the file named after the title. When a prefix
+is set, the file name becomes prefix + underscore + title.
+
 ## Example
 
 A sudoers entry can be defined within a class or node definition:

--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -38,6 +38,9 @@
 # [*defaults*]
 #   Override some of the compiled in default values for sudo.
 #
+# [*prefix*]
+#   Prefix for the file, when ordering matters.
+#
 # === Examples
 #
 # sudo::sudoers { 'worlddomination':
@@ -68,16 +71,29 @@ define sudo::sudoers (
   $runas    = ['root'],
   $tags     = [],
   $defaults = [],
+  $prefix   = undef,
 ) {
+
+  # filename prefix, since the order of multiple matching rules matters (the
+  # last one found is used), optional and with '_' separator added
+  if $prefix != undef {
+    if $prefix !~ /^[A-Za-z0-9_-]+$/ {
+      fail "Invalid file prefix \"${prefix}\", should consist of letters numbers underscores or dashes"
+    } else {
+      $sane_prefix = "${prefix}_"
+    }
+  } else {
+    $sane_prefix = ''
+  }
 
   # filename as per the manual or aliases as per the sudoer spec must not
   # contain dots.
   # As having dots in a username is legit, let's fudge
   $sane_name = regsubst($name, '\.', '_', 'G')
-  $sudoers_user_file = "/etc/sudoers.d/${sane_name}"
+  $sudoers_user_file = "/etc/sudoers.d/${sane_prefix}${sane_name}"
 
   if $sane_name !~ /^[A-Za-z][A-Za-z0-9_]*$/ {
-    fail "Will not create sudoers file \"${sudoers_user_file}\" (for user \"${name}\") should consist of letters numbers or underscores."
+    fail "Will not create sudoers file \"${sudoers_user_file}\" (for \"${name}\") should consist of letters numbers or underscores."
   }
 
   if $users != undef and $group != undef {

--- a/spec/defines/sudo_sudoers_spec.rb
+++ b/spec/defines/sudo_sudoers_spec.rb
@@ -45,6 +45,22 @@ describe 'sudo::sudoers', :type => :define do
     it { should contain_file('/etc/sudoers.d/world_domination').with_content(/Defaults!WORLD_DOMINATION_CMNDS env_keep \+= "SSH_AUTH_SOCK"/) }
 
   end
+
+  context 'setting sudo with a prefix' do
+    let(:params) { {
+      :users    => ['pinky', 'brain'],
+      :comment  => 'Today we\'re going to take over the world',
+      :runas    => ['animaniacs'],
+      :cmnds    => ['/bin/bash'],
+      :tags     => ['LOG_INPUT', 'LOG_OUTPUT'],
+      :defaults => [ 'env_keep += "SSH_AUTH_SOCK"' ],
+      :prefix   => '00'
+    } }
+
+    it { should contain_file('/etc/sudoers.d/00_world_domination').with_content(/^# Today\swe\'re\sgoing\sto\stake\sover\sthe\sworld$/) }
+
+  end
+
   if (Puppet.version >= '3.5.0')
     context "validating content with puppet #{Puppet.version}" do
       let(:params) { { :users => ['joe'] } }


### PR DESCRIPTION
The order of the sudo rules matters, and the $title may not start with
numbers since it's used as-is for the sudo users, cmds, etc. aliases. It
was possible to add 'a_', 'z_', etc. to current titles, but it's cleaner
to force ordering by relying on an optional separate parameter.
