### PR TITLE
bump stdlib dependency to >=4.0.0 and use ensure_packages()

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,9 +45,7 @@ class sudo (
 
   create_resources('sudo::sudoers', $sudoers)
 
-  package { 'sudo':
-    ensure  => latest
-  }
+  ensure_packages( ['sudo'] )
 
   file { '/etc/sudoers.d/':
     ensure  => directory,

--- a/metadata.json
+++ b/metadata.json
@@ -57,6 +57,6 @@
   ],
   "tags": ["sudo", "security"],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=4.0.0" }
   ]
 }


### PR DESCRIPTION
There other packages out there (i.e. [nvogel-ansible](https://github.com/nvogel/puppet-ansible) that want `sudo` installed. Switching from `Package` resource to stdlib's `ensure_packages()` function would make them coexist without throwing _Duplicate declaration_ errors.

This patch bumps stdlib dependency to v4.0.0, which is the first version with `ensure_packages()`, and uses that function to be nice with other modules.
