### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class sudo (
     ensure  => latest
   }
 
-  file { '/etc/sudoers.d/':
+  file { '/etc/sudoers.d':
     ensure  => directory,
     owner   => 'root',
     group   => 'root',


### PR DESCRIPTION
[language-puppet](https://github.com/bartavelle/language-puppet)` has a rule to forbid the extra `/`. I would argue it is cleaner that way but if you disagree I would propose the removal of the rule (note that I am using many puppetlabs modules and they all conform to it).

Cheers