### PR TITLE
Make package::ensure configurable via a class parameter and set it to "installed" by default.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,13 +40,14 @@
 class sudo (
   $sudoers         = {},
   $manage_sudoersd = false,
-  $sudoers_file    = ''
+  $sudoers_file    = '',
+  $package_ensure  = 'installed',
 ) {
 
   create_resources('sudo::sudoers', $sudoers)
 
   package { 'sudo':
-    ensure  => latest
+    ensure  => $package_ensure
   }
 
   file { '/etc/sudoers.d':

--- a/spec/classes/sudo_init_spec.rb
+++ b/spec/classes/sudo_init_spec.rb
@@ -13,7 +13,7 @@ describe 'sudo', :type => :class do
   }
 
   context 'no params' do
-    it { should contain_package('sudo').with_ensure('latest') }
+    it { should contain_package('sudo').with_ensure('installed') }
     it { should contain_file('/etc/sudoers.d/').with(
       'purge'   => 'false',
       'recurse' => 'false',


### PR DESCRIPTION
Always installing the latest version of the `sudo` package might cause unexpected side effects. Using "installed" for `package::ensure` makes more sense in my point of view. Also, a class parameter to set `package::ensure` brings in more flexibility.
