### PR TITLE
Allow setting validate_cmd command as a parameter

### DIFF
--- a/manifests/sudoers.pp
+++ b/manifests/sudoers.pp
@@ -68,6 +68,7 @@ define sudo::sudoers (
   $runas    = ['root'],
   $tags     = [],
   $defaults = [],
+  $validate_command = '/usr/sbin/visudo -c -f %'
 ) {
 
   # filename as per the manual or aliases as per the sudoer spec must not
@@ -92,10 +93,10 @@ define sudo::sudoers (
       mode    => '0440',
     }
     if versioncmp($::puppetversion, '3.5') >= 0 {
-      File[$sudoers_user_file] { validate_cmd => '/usr/sbin/visudo -c -f %' }
+      File[$sudoers_user_file] { validate_cmd => $validate_command }
     }
     else {
-      validate_cmd(template('sudo/sudoers.erb'), '/usr/sbin/visudo -c -f', 'Visudo failed to validate sudoers content')
+      validate_cmd(template('sudo/sudoers.erb'), $validate_command, 'Visudo failed to validate sudoers content')
     }
   }
   else {


### PR DESCRIPTION
- I've found putting a cat before the visudo allows better debugging. But it's easier to just allow a user to pick what they want, so lets do that as a parameter! 😄 

```
validate_command = '/bin/cat % && /usr/sbin/visudo -c -f %`
```

```
Error: Execution of '/bin/cat /etc/sudoers.d/FAIL20160420-3555-17pxezk && /usr/sbin/visudo -c -f /etc/sudoers.d/FAIL20160420-3555-17pxezk' returned 1: # Managed by Puppet! Do not edit locally.


  #
  # This should fail

  Host_Alias  FAIL_HOSTS = ALL
  Runas_Alias FAIL_RUNAS = root
  Cmnd_Alias  FAIL_CMNDS = ALL


  % FAIL_HOSTS = (FAIL_RUNAS) NOPASSWD: FAIL_CMNDS
  visudo: >>> /etc/sudoers.d/FAIL20160420-3555-17pxezk: syntax error near line 12 <<<
  parse error in /etc/sudoers.d/FAIL20160420-3555-17pxezk near line 12
  Error: /Stage[main]/Main/Sudo::Sudoers[FAIL]/File[/etc/sudoers.d/FAIL]/ensure: change from absent to file failed: Execution of '/bin/cat /etc/sudoers.d/FAIL20160420-3555-17pxezk && /usr/sbin/visudo -c -f /etc/sudoers.d/FAIL20160420-3555-17pxezk' returned 1: # Managed by Puppet! Do not edit locally.
```
