### PR TITLE
Fixes Ubuntu image failing during Beaker tests

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -2,7 +2,7 @@ HOSTS:
   ubuntu-server-12042-x64:
     roles:
       - master
-    platform: ubuntu-server-12.04-amd64
+    platform: ubuntu-12.04-amd64
     box: ubuntu-server-12042-x64-vbox4210-nocm
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
     hypervisor: vagrant

--- a/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
@@ -2,7 +2,7 @@ HOSTS:
   ubuntu-server-12042-x64:
     roles:
       - master
-    platform: ubuntu-server-12.04-amd64
+    platform: ubuntu-12.04-amd64
     box: ubuntu-server-12042-x64-vbox4210-nocm
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
     hypervisor: vagrant


### PR DESCRIPTION
Running the acceptance tests I ran into the following error:

> ubuntu-server-12042-x64 10:05:52$ wget -O /tmp/puppet.deb http://apt.puppetlabs.com/puppetlabs-release-.deb
> --2016-05-10 08:05:51--  http://apt.puppetlabs.com/puppetlabs-release-.deb
> Resolving apt.puppetlabs.com (apt.puppetlabs.com)...   192.155.89.90, 2600:3c03::f03c:91ff:fedb:6b1d
> Connecting to apt.puppetlabs.com (apt.puppetlabs.com)|192.155.89.90|:80...   connected.
> HTTP request sent, awaiting response...   404 Not Found
> 2016-05-10 08:05:51 ERROR 404: Not Found.

Which lead me to this post:
https://groups.google.com/forum/#!topic/puppet-users/A7UrwTRCzsU

Assuming it worked before I'm guessing this issue was introduced with some more recent Beaker release. In any case, [looking at the Beaker source](https://github.com/puppetlabs/beaker/blob/f00e942f29d61ed8f79b4e5f7ac9f9eaae38c0b0/lib/beaker/platform.rb#L74) indicates that `ubuntu-server-12.04-amd64` should indeed be `ubuntu-12.04-amd64`.

With this change, the tests pass for me using Beaker 2.40.
